### PR TITLE
Limit WebGL animation to the empty state

### DIFF
--- a/discollection-web/app/layout.tsx
+++ b/discollection-web/app/layout.tsx
@@ -3,7 +3,6 @@ import { Toaster } from "@/components/ui/sonner";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import { FractalBackground } from "@/components/FractalBackground";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -29,7 +28,6 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <FractalBackground />
           {children}
           <Toaster />
         </ThemeProvider>

--- a/discollection-web/app/page.tsx
+++ b/discollection-web/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FractalBackground } from "@/components/FractalBackground";
 import { useCollectionStore } from "@/state/collection";
 import { InfiniteCanvasFlow } from "@/components/InfiniteCanvasFlow";
 import { SidePanel } from "@/components/SidePanel";
@@ -60,6 +61,7 @@ export default function Home() {
   if (!collection) {
     return (
       <div className="empty-state-shell">
+        <FractalBackground />
         <main className="relative z-10 mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center justify-center px-6 py-16">
           <h1 className="empty-title font-mono">discollection</h1>
 

--- a/discollection-web/components/FractalBackground.tsx
+++ b/discollection-web/components/FractalBackground.tsx
@@ -351,6 +351,16 @@ export function FractalBackground() {
 
     mediaQuery.addEventListener("change", onMediaChange);
 
+    const draw = (time: number) => {
+      gl.useProgram(program);
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.enableVertexAttribArray(positionLoc);
+      gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+      gl.uniform2f(resolutionLoc, canvas.width, canvas.height);
+      gl.uniform1f(timeLoc, time);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    };
+
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
       const width = Math.floor(canvas.clientWidth * dpr);
@@ -362,29 +372,19 @@ export function FractalBackground() {
       }
 
       gl.viewport(0, 0, canvas.width, canvas.height);
+      draw(reduceMotion ? 0 : (performance.now() - start) * 0.001);
+    };
+
+    let rafId = 0;
+    const start = performance.now();
+    const render = (now: number) => {
+      const elapsed = (now - start) * 0.001;
+      draw(reduceMotion ? 0 : elapsed);
+      rafId = window.requestAnimationFrame(render);
     };
 
     resize();
     window.addEventListener("resize", resize);
-
-    let rafId = 0;
-    const start = performance.now();
-
-    const render = (now: number) => {
-      const elapsed = (now - start) * 0.001;
-      const time = reduceMotion ? 0.0 : elapsed;
-
-      gl.useProgram(program);
-      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-      gl.enableVertexAttribArray(positionLoc);
-      gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
-      gl.uniform2f(resolutionLoc, canvas.width, canvas.height);
-      gl.uniform1f(timeLoc, time);
-      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
-
-      rafId = window.requestAnimationFrame(render);
-    };
-
     rafId = window.requestAnimationFrame(render);
 
     return () => {


### PR DESCRIPTION
## Summary
- remove the fractal WebGL background from the shared app layout
- render the background only when no collection JSON has been loaded yet
- keep the background animated in the empty state while avoiding continuous animation cost in the collection view

## Validation
- pnpm --filter discollection-web exec tsc --noEmit