### PR TITLE
feat: add mise for tool version management and improve locate command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9.6.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,14 @@
+[tools]
+node = "22.22.0"
+pnpm = "9.6.0"
+
+# Voice locate dependencies (macOS)
+# Homebrew packages use latest; tested versions noted below
+# ffmpeg tested: 8.0.1
+# whisper-cpp tested: 1.8.4
+"brew:ffmpeg" = "latest"
+"brew:whisper-cpp" = "latest"
+
+[env]
+# Uncomment to set default DB path
+# DISCOLLECTION_DB_PATH = "./discollection.db"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export DISCOLLECTION_DB_PATH="./tmp/discollection.db"
 pnpm --filter discollection dev sync
 pnpm --filter discollection dev seed --config /absolute/path/to/config.discollection.json
 pnpm --filter discollection dev organize ./tmp/organized.json
-pnpm --filter discollection dev locate ./tmp/organized.json --once --voice Daniel --speech-rate 200
+pnpm --filter discollection dev locate --collection ./tmp/organized.json --once --voice Daniel --speech-rate 200
 ```
 
 Voice capture mode for `locate` requires `ffmpeg`, `whisper-cli`, and a local Whisper model. Text queries can run without those dependencies. See the CLI README for setup details.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Workflow guides for managing your physical vinyl collection: **Crate â†’ File â†
 
 ## Quick Start
 
+### Prerequisites
+
+Install [mise](https://mise.jdx.dev/) to manage tool versions:
+
+```bash
+curl https://mise.run | sh
+mise install
+```
+
+This installs Node.js, pnpm, and voice dependencies (ffmpeg, whisper-cpp) at the pinned versions.
+
+### Build
+
 ```bash
 pnpm install
 pnpm build

--- a/discollection-cli/README.md
+++ b/discollection-cli/README.md
@@ -7,11 +7,12 @@ CLI to sync a Discogs collection into SQLite and generate organized JSON output.
 - `sync`: pull collection data from Discogs into local DB.
 - `seed --config <path>`: store overrides and organize config in DB.
 - `organize <output> [--config <path>]`: generate organized JSON from DB.
-- `locate <collectionPath> [query]`: locate a release in an organized collection JSON using the current voice-first workflow.
+- `locate [query]`: locate a release in an organized collection. Uses `--collection <path>` for a specific JSON file, otherwise organizes fresh from the database.
 - `release-override <releaseId> <overrideValue>`: add/update one release override row in DB. Override type is inferred: values matching official Discogs genres are saved as `genre`, otherwise as `style`.
 
 ### `locate` options
 
+- `--collection <path>`: path to an organized collection JSON. If omitted, organizes from the database.
 - `--lang <code>`: Whisper language code. Default: `en`.
 - `--no-speak`: print results without reading them aloud through macOS `say`.
 - `--voice <name>`: macOS `say` voice override. Default: `Samantha`.
@@ -79,26 +80,26 @@ pnpm --filter discollection dev seed --config /absolute/path/to/config.discollec
 pnpm --filter discollection dev release-override 12345 Rock
 pnpm --filter discollection dev release-override 12345 "Hard Rock"
 pnpm --filter discollection dev organize ./tmp/organized.json
-pnpm --filter discollection dev locate ./tmp/organized.json --once --voice Daniel --speech-rate 200
+pnpm --filter discollection dev locate --collection ./tmp/organized.json --once --voice Daniel --speech-rate 200
 ```
 
 Run a single text lookup against an existing organized export:
 
 ```bash
-pnpm --filter discollection dev locate ./tmp/organized.json "Kind of Blue"
+pnpm --filter discollection dev locate "Kind of Blue" --collection ./tmp/organized.json
 ```
 
 Run the continuous voice loop and say `stop listening` to exit:
 
 ```bash
-pnpm --filter discollection dev locate ./tmp/organized.json --voice Daniel --speech-rate 200
+pnpm --filter discollection dev locate --collection ./tmp/organized.json --voice Daniel --speech-rate 200
 ```
 
 Run built CLI binary:
 
 ```bash
 pnpm --filter discollection start -- organize ./tmp/organized.json
-pnpm --filter discollection start -- locate ./tmp/organized.json --once
+pnpm --filter discollection start -- locate --collection ./tmp/organized.json --once
 ```
 
 ## Config File Schema

--- a/discollection-cli/README.md
+++ b/discollection-cli/README.md
@@ -37,7 +37,18 @@ export DISCOLLECTION_DB_PATH="./tmp/discollection.db"
 
 Voice capture mode requires local voice dependencies. Text queries can run without Whisper.
 
-Install runtime dependencies on macOS:
+### Using mise (recommended)
+
+From the repo root, mise installs all dependencies including ffmpeg and whisper-cpp:
+
+```bash
+mise install
+whisper-download-ggml-model base.en
+```
+
+### Manual installation
+
+If not using mise, install runtime dependencies on macOS:
 
 ```bash
 brew install ffmpeg whisper-cpp

--- a/discollection-cli/package.json
+++ b/discollection-cli/package.json
@@ -31,7 +31,6 @@
   "keywords": [],
   "license": "ISC",
   "name": "discollection",
-  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e",
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/cli.ts",

--- a/discollection-cli/src/commands/locate.test.ts
+++ b/discollection-cli/src/commands/locate.test.ts
@@ -75,6 +75,15 @@ vi.mock("../utilities/locate-search", () => ({
   createLocateSearcher: mocks.createLocateSearcher,
 }));
 
+vi.mock("../utilities/organize", () => ({
+  loadOrganizeDataFromDb: () => ({
+    collection: [],
+    overrides: { genre: {}, style: {} },
+    dbConfig: { subgroup: [], consolidate: {} },
+  }),
+  buildOrganizedLibrary: () => ({}),
+}));
+
 vi.mock("../utilities/release", () => ({
   getReleasePrimaryArtist: (release: { basic_information: { artists?: Array<{ name: string }> } }) =>
     release.basic_information.artists?.[0]?.name,
@@ -98,7 +107,7 @@ describe("locateAction", () => {
   it("runs text queries without requiring whisper dependencies", async () => {
     const { locateAction } = await import("./locate");
 
-    await locateAction("./organized.json", "kind of blue", { speak: false });
+    await locateAction("kind of blue", { collection: "./organized.json", speak: false });
 
     expect(mocks.canUseWhisperVoiceMode).not.toHaveBeenCalled();
     expect(mocks.resolveDefaultWhisperModelPath).not.toHaveBeenCalled();

--- a/discollection-cli/src/commands/locate.ts
+++ b/discollection-cli/src/commands/locate.ts
@@ -4,7 +4,11 @@ import logger from "../logger";
 import type { Release } from "../types";
 import { buildLocatedReleases, type LocatedRelease } from "../utilities/locate";
 import { createLocateSearcher } from "../utilities/locate-search";
-import type { OrganizedLibrary } from "../utilities/organize";
+import {
+  buildOrganizedLibrary,
+  loadOrganizeDataFromDb,
+  type OrganizedLibrary,
+} from "../utilities/organize";
 import { getReleasePrimaryArtist } from "../utilities/release";
 import {
   canUseWhisperVoiceMode,
@@ -14,6 +18,7 @@ import {
 import { speakWithMacosSay } from "../speech/macos-say";
 
 type LocateOptions = {
+  collection?: string;
   lang?: string;
   speak?: boolean;
   voice?: string;
@@ -40,6 +45,19 @@ function loadOrganizedCollectionFromFile(
   }
 
   return parsed;
+}
+
+function loadOrganizedCollectionFromDb(): OrganizedLibrary {
+  const { collection, overrides, dbConfig } = loadOrganizeDataFromDb();
+
+  logger.info("Organizing collection from database", { total: collection.length });
+
+  return buildOrganizedLibrary(collection, {
+    subgroup: dbConfig.subgroup,
+    consolidate: dbConfig.consolidate,
+    genre: overrides.genre,
+    style: overrides.style,
+  });
 }
 
 function releaseLabel(release: Release): string {
@@ -124,13 +142,14 @@ async function getQueryFromVoice(
 }
 
 export const locateAction = async (
-  collectionPath: string,
   queryArg: string | undefined,
   options: LocateOptions,
 ) => {
-  logger.info("Starting locate session", { collectionPath, options });
+  logger.info("Starting locate session", { collection: options.collection, options });
 
-  const organized = loadOrganizedCollectionFromFile(collectionPath);
+  const organized = options.collection
+    ? loadOrganizedCollectionFromFile(options.collection)
+    : loadOrganizedCollectionFromDb();
   const located = buildLocatedReleases(organized);
   const searcher = createLocateSearcher(located);
   const stopPhrase = (options.stopPhrase ?? "stop listening").toLowerCase();

--- a/discollection-cli/src/index.ts
+++ b/discollection-cli/src/index.ts
@@ -20,7 +20,8 @@ function main() {
   cli.command("sync").action(syncAction);
 
   cli
-    .command("locate <collectionPath> [query]")
+    .command("locate [query]")
+    .option("--collection <path>", "Path to organized collection JSON (default: organize from DB)")
     .option("--lang <code>", "Language code for whisper (default: en)")
     .option("--no-speak", "Disable spoken response output")
     .option("--voice <name>", "macOS say voice override (default: Samantha)")

--- a/docs/guides/03-dig.md
+++ b/docs/guides/03-dig.md
@@ -11,17 +11,24 @@
 ## Text Search
 
 ```bash
-discollection locate ./my-collection.json "Kind of Blue"
+# Using database (organizes fresh)
+discollection locate "Kind of Blue"
+
+# Using existing collection file
+discollection locate "Kind of Blue" --collection ./my-collection.json
 ```
 
 ## Voice Search
 
 ```bash
 # Continuous mode (say "stop listening" to exit)
-discollection locate ./my-collection.json
+discollection locate
 
 # Single query mode
-discollection locate ./my-collection.json --once
+discollection locate --once
+
+# With collection file
+discollection locate --collection ./my-collection.json --once
 ```
 
 ## Reading the Result
@@ -41,6 +48,7 @@ Between: A Love Supreme | Brilliant Corners
 
 | Option | What it does |
 |--------|--------------|
+| `--collection <path>` | Use existing organized JSON |
 | `--voice Samantha` | Change speaking voice |
 | `--speech-rate 180` | Slower/faster speech |
 | `--no-speak` | Text output only |
@@ -49,5 +57,5 @@ Between: A Love Supreme | Brilliant Corners
 ## Example
 
 ```bash
-discollection locate ./my-collection.json --voice Daniel --speech-rate 200 --once
+discollection locate --voice Daniel --speech-rate 200 --once
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "discollection-monorepo",
   "description": "Monorepo for Discogs collection tooling: a sync/organize CLI, shared SQLite+Drizzle DB package, and Next.js web viewer.",
   "private": true,
-  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e",
   "dependencies": {
     "discollection": "workspace:*"
   },


### PR DESCRIPTION
## Summary

This PR adds mise for unified tool version management and improves the `locate` command by making the collection path optional.

## Changes

### Tool Version Management with mise
- Add `.mise.toml` pinning node 22.22.0, pnpm 9.6.0, and brew packages (ffmpeg, whisper-cpp)
- Remove `packageManager` field from package.json files (now managed by mise)
- Update README.md with mise setup instructions in Quick Start
- Update discollection-cli/README.md with mise section for voice dependencies

### Locate Command Improvements
- Change `collectionPath` from positional argument to `--collection` option
- When `--collection` is omitted, organize fresh from database (no file needed)
- Add `loadOrganizedCollectionFromDb()` to build collection in-memory
- Update CLI README, user guide (03-dig.md), and tests

## Usage

```bash
# Install all tools with mise
mise install

# Locate with database (no file needed)
discollection locate "Kind of Blue"

# Locate with existing collection file  
discollection locate "Kind of Blue" --collection ./organized.json
```